### PR TITLE
Enable dwell time on US915 uplinks

### DIFF
--- a/US_902_928_FSB_1.yml
+++ b/US_902_928_FSB_1.yml
@@ -36,6 +36,10 @@ lora-standard-channel:
   frequency: 903000000
   data-rate: 12
   radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
 radios:
 - enable: true
   chip-type: SX1257

--- a/US_902_928_FSB_2.yml
+++ b/US_902_928_FSB_2.yml
@@ -36,6 +36,10 @@ lora-standard-channel:
   frequency: 904600000
   data-rate: 12
   radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
 radios:
 - enable: true
   chip-type: SX1257


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR enables the 400msec dwell time on US915 uplinks.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Since these frequency plans use less than 50 channels, end devices actually use "Hybrid mode", so we should probably also change the max EIRP.

<img width="861" alt="Screenshot 2019-11-21 at 10 04 20" src="https://user-images.githubusercontent.com/181308/69323074-4ef2cb00-0c46-11ea-8d47-f55b69b40360.png">

However, we can only define a single max EIRP in the frequency plan, and that will apply to both end devices and gateways. This probably isn't what we want, so perhaps we should add the `SubBands` (from `pkg/band` in `lorawan-stack`) to the frequency plan definition?