### PR TITLE
Add country codes to list of frequency plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ An index of frequency plans is in `frequency-plans.yml`:
   base-id: EU_863_870      # ID that this frequency plan extends
   name: Region 863-870 MHz # Name of the frequency plan, ending with frequency ranges
   base-frequency: 868      # Base frequency in MHz for hardware support (433, 470, 868 or 915)
-  country-codes: []        # List of ISO country codes for countries where this plan can be used
+  country-codes: []        # List of 2-digit ISO country codes for countries where this plan can be used
   file: EU_863_870.yml     # File of the frqeuency plan definition
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ An index of frequency plans is in `frequency-plans.yml`:
   base-id: EU_863_870      # ID that this frequency plan extends
   name: Region 863-870 MHz # Name of the frequency plan, ending with frequency ranges
   base-frequency: 868      # Base frequency in MHz for hardware support (433, 470, 868 or 915)
+  country-codes: []        # List of ISO country codes for countries where this plan can be used
   file: EU_863_870.yml     # File of the frqeuency plan definition
 ```
 

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -118,5 +118,5 @@
   name: LoRa 2.4 GHz with 3 channels draft 2
   description: LoRa 2.4 GHz plan with 3 channels for global use draft 2
   base-frequency: 2450
-  country-codes: []
+  country-codes: [af, ax, al, dz, as, ad, ao, ai, aq, ag, ar, am, aw, au, at, az, bs, bh, bd, bb, by, be, bz, bj, bm, bt, bo, ba, bw, bv, br, io, bn, bg, bf, bi, kh, cm, ca, cv, ky, cf, td, cl, cn, cx, cc, co, km, cg, cd, ck, cr, ci, hr, cu, cy, cz, dk, dj, dm, do, ec, eg, sv, gq, er, ee, et, fk, fo, fj, fi, fr, gf, pf, tf, ga, gm, ge, de, gh, gi, gr, gl, gd, gp, gu, gt, gg, gn, gw, gy, ht, hm, va, hn, hk, hu, is, in, id, ir, iq, ie, im, il, it, jm, jp, je, jo, kz, ke, ki, kp, kr, kw, kg, la, lv, lb, ls, lr, ly, li, lt, lu, mo, mk, mg, mw, my, mv, ml, mt, mh, mq, mr, mu, yt, mx, fm, md, mc, mn, me, ms, ma, mz, mm, na, nr, np, nl, an, nc, nz, ni, ne, ng, nu, nf, mp, no, om, pk, pw, ps, pa, pg, py, pe, ph, pn, pl, pt, pr, qa, re, ro, ru, rw, bl, sh, kn, lc, mf, pm, vc, ws, sm, st, sa, sn, rs, sc, sl, sg, sk, si, sb, so, za, gs, es, lk, sd, sr, sj, sz, se, ch, sy, tw, tj, tz, th, tl, tg, tk, to, tt, tn, tr, tm, tc, tv, ug, ua, ae, gb, us, um, uy, uz, vu, ve, vn, vg, vi, wf, eh, ye, zm, zw]
   file: ISM_2400_3CH_DRAFT2.yml

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -2,7 +2,7 @@
   name: Europe 863-870 MHz
   description: Default frequency plan for Europe
   base-frequency: 868
-  country-codes: []
+  country-codes: [al, ad, ao, at, bh, be, ba, bw, bg, cg, hr, cy, cz, dk, ee, sz, fi, fr, gr, hu, is, ie, it, lv, ls, li, lt, lu, mg, mw, mt, mu, md, me, mz, na, nl, mk, ph, pl, pt, ro, ru, sa, rs, sc, sk, si, za, es, se, ch, tz, tr, ae, gb, va, zm, zw]
   file: EU_863_870.yml
 
 - id: EU_863_870_TTN
@@ -10,56 +10,56 @@
   description: TTN Community Network frequency plan for Europe, using SF9 for Rx2
   base-frequency: 868
   base-id: EU_863_870
-  country-codes: []
+  country-codes: [al, ad, ao, at, bh, be, ba, bw, bg, cg, hr, cy, cz, dk, ee, sz, fi, fr, gr, hu, is, ie, it, lv, ls, li, lt, lu, mg, mw, mt, mu, md, me, mz, na, nl, mk, ph, pl, pt, ro, ru, sa, rs, sc, sk, si, za, es, se, ch, tz, tr, ae, gb, va, zm, zw]
   file: EU_863_870_TTN.yml
 
 - id: US_902_928_FSB_1
   name: United States 902-928 MHz, FSB 1
   description: Default frequency plan for the United States and Canada, using sub-band 1
   base-frequency: 915
-  country-codes: []
+  country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
   file: US_902_928_FSB_1.yml
 
 - id: US_902_928_FSB_2
   name: United States 902-928 MHz, FSB 2 (TTN)
   description: TTN Community Network frequency plan for the United States and Canada, using sub-band 2
   base-frequency: 915
-  country-codes: []
+  country-codes: [[bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
   file: US_902_928_FSB_2.yml
 
 - id: AU_915_928_FSB_1
   name: Australia 915-928 MHz, FSB 1
   description: Default frequency plan for Australia, using sub-band 1
   base-frequency: 915
-  country-codes: []
+  country-codes: [br, cl, nz, ar, au]
   file: AU_915_928_FSB_1.yml
 
 - id: AU_915_928_FSB_2
   name: Australia 915-928 MHz, FSB 2 (TTN)
   description: TTN Community Network frequency plan for Australia, using sub-band 2
   base-frequency: 915
-  country-codes: []
+  country-codes: [br, cl, nz, ar, au]
   file: AU_915_928_FSB_2.yml
 
 - id: AU_915_928_FSB_6
   name: Australia 915-928 MHz, FSB 6
   description: Frequency plan for Australia, using sub-band 6, which overlaps with Asia 923-925 MHz
   base-frequency: 915
-  country-codes: []
+  country-codes: [br, cl, nz, ar, au]
   file: AU_915_928_FSB_6.yml
 
 - id: CN_470_510_FSB_11
   name: China 470-510 MHz, FSB 11
   description: TTN Community Network frequency plan for China, using sub-band 11
   base-frequency: 470
-  country-codes: []
+  country-codes: [cn]
   file: CN_470_510_FSB_11.yml
 
 - id: AS_920_923
   name: Asia 920-923 MHz
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≤ 923 MHz
   base-frequency: 915
-  country-codes: []
+  country-codes: [jp, my, sg]
   file: AS_920_923.yml
 
 - id: AS_920_923_LBT
@@ -67,14 +67,14 @@
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≤ 923 MHz with listen-before-talk
   base-frequency: 915
   base-id: AS_920_923
-  country-codes: []
+  country-codes: [jp, my, sg]
   file: lbt_80_over_128.yml
 
 - id: AS_923_925
   name: Asia 923-925 MHz
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≥ 923 MHz
   base-frequency: 915
-  country-codes: []
+  country-codes: [bn, kh, hk, id, la, tw, th, vn]
   file: AS_923_925.yml
 
 - id: AS_923_925_LBT
@@ -82,7 +82,7 @@
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≥ 923 MHz with listen-before-talk
   base-frequency: 915
   base-id: AS_923_925
-  country-codes: []
+  country-codes: [bn, kh, hk, id, la, tw, th, vn]
   file: lbt_80_over_128.yml
 
 - id: AS_923_925_TTN_AU
@@ -90,21 +90,21 @@
   description: TTN Community Network frequency plan for Asia 923-925 MHz in Australia
   base-frequency: 915
   base-id: AS_923_925
-  country-codes: []
+  country-codes: [au]
   file: AS_923_925_TTN_AU.yml
 
 - id: KR_920_923_TTN
   name: South Korea 920-923 MHz
   description: TTN Community Network frequency plan for South Korea
   base-frequency: 915
-  country-codes: []
+  country-codes: [kr]
   file: KR_920_923_TTN.yml
 
 - id: IN_865_867
   name: India 865-867 MHz
   description: Default frequency plan for India
   base-frequency: 868
-  country-codes: []
+  country-codes: [in]
   file: IN_865_867.yml
 
 - id: RU_864_870_TTN

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -24,7 +24,7 @@
   name: United States 902-928 MHz, FSB 2 (TTN)
   description: TTN Community Network frequency plan for the United States and Canada, using sub-band 2
   base-frequency: 915
-  country-codes: [[bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
+  country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
   file: US_902_928_FSB_2.yml
 
 - id: AU_915_928_FSB_1
@@ -59,7 +59,7 @@
   name: Asia 920-923 MHz
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≤ 923 MHz
   base-frequency: 915
-  country-codes: [jp, my, sg]
+  country-codes: [my, sg]
   file: AS_920_923.yml
 
 - id: AS_920_923_LBT

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -2,6 +2,7 @@
   name: Europe 863-870 MHz
   description: Default frequency plan for Europe
   base-frequency: 868
+  country-codes: []
   file: EU_863_870.yml
 
 - id: EU_863_870_TTN
@@ -9,48 +10,56 @@
   description: TTN Community Network frequency plan for Europe, using SF9 for Rx2
   base-frequency: 868
   base-id: EU_863_870
+  country-codes: []
   file: EU_863_870_TTN.yml
 
 - id: US_902_928_FSB_1
   name: United States 902-928 MHz, FSB 1
   description: Default frequency plan for the United States and Canada, using sub-band 1
   base-frequency: 915
+  country-codes: []
   file: US_902_928_FSB_1.yml
 
 - id: US_902_928_FSB_2
   name: United States 902-928 MHz, FSB 2 (TTN)
   description: TTN Community Network frequency plan for the United States and Canada, using sub-band 2
   base-frequency: 915
+  country-codes: []
   file: US_902_928_FSB_2.yml
 
 - id: AU_915_928_FSB_1
   name: Australia 915-928 MHz, FSB 1
   description: Default frequency plan for Australia, using sub-band 1
   base-frequency: 915
+  country-codes: []
   file: AU_915_928_FSB_1.yml
 
 - id: AU_915_928_FSB_2
   name: Australia 915-928 MHz, FSB 2 (TTN)
   description: TTN Community Network frequency plan for Australia, using sub-band 2
   base-frequency: 915
+  country-codes: []
   file: AU_915_928_FSB_2.yml
 
 - id: AU_915_928_FSB_6
   name: Australia 915-928 MHz, FSB 6
   description: Frequency plan for Australia, using sub-band 6, which overlaps with Asia 923-925 MHz
   base-frequency: 915
+  country-codes: []
   file: AU_915_928_FSB_6.yml
 
 - id: CN_470_510_FSB_11
   name: China 470-510 MHz, FSB 11
   description: TTN Community Network frequency plan for China, using sub-band 11
   base-frequency: 470
+  country-codes: []
   file: CN_470_510_FSB_11.yml
 
 - id: AS_920_923
   name: Asia 920-923 MHz
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≤ 923 MHz
   base-frequency: 915
+  country-codes: []
   file: AS_920_923.yml
 
 - id: AS_920_923_LBT
@@ -58,12 +67,14 @@
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≤ 923 MHz with listen-before-talk
   base-frequency: 915
   base-id: AS_920_923
+  country-codes: []
   file: lbt_80_over_128.yml
 
 - id: AS_923_925
   name: Asia 923-925 MHz
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≥ 923 MHz
   base-frequency: 915
+  country-codes: []
   file: AS_923_925.yml
 
 - id: AS_923_925_LBT
@@ -71,6 +82,7 @@
   description: TTN Community Network frequency plan for Asian countries, using frequencies ≥ 923 MHz with listen-before-talk
   base-frequency: 915
   base-id: AS_923_925
+  country-codes: []
   file: lbt_80_over_128.yml
 
 - id: AS_923_925_TTN_AU
@@ -78,28 +90,33 @@
   description: TTN Community Network frequency plan for Asia 923-925 MHz in Australia
   base-frequency: 915
   base-id: AS_923_925
+  country-codes: []
   file: AS_923_925_TTN_AU.yml
 
 - id: KR_920_923_TTN
   name: South Korea 920-923 MHz
   description: TTN Community Network frequency plan for South Korea
   base-frequency: 915
+  country-codes: []
   file: KR_920_923_TTN.yml
 
 - id: IN_865_867
   name: India 865-867 MHz
   description: Default frequency plan for India
   base-frequency: 868
+  country-codes: []
   file: IN_865_867.yml
 
 - id: RU_864_870_TTN
   name: Russia 864-870 MHz
   description: TTN Community Network frequency plan for Russia
   base-frequency: 868
+  country-codes: [ru]
   file: RU_864_870_TTN.yml
 
 - id: ISM_2400_3CH_DRAFT2
   name: LoRa 2.4 GHz with 3 channels draft 2
   description: LoRa 2.4 GHz plan with 3 channels for global use draft 2
   base-frequency: 2450
+  country-codes: []
   file: ISM_2400_3CH_DRAFT2.yml


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add country codes to list of frequency plans

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This list of country codes is taken directly from https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country.html

There may be mistakes - it looks like Indonesia is AS923-925 according to [this](https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country.html) but it is AS920-923 according to [this ](https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html)

Is there a single, reputable source somewhere with this kind of info? I'd also like to figure out exactly which countries (outside of Australia) AS923 FSB 6 is allowed in.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [x] Documentation: Relevant documentation is added or updated.
