### PR TITLE
Add missing FSBs for US and AU

### DIFF
--- a/AU_915_928_FSB_3.yml
+++ b/AU_915_928_FSB_3.yml
@@ -1,0 +1,51 @@
+band-id: AU_915_928
+uplink-channels:
+- frequency: 918400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 918600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 918800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 919000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 919200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 919400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 919600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 919800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+lora-standard-channel:
+  frequency: 919100000
+  data-rate: 12
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 918800000
+  rssi-offset: -166
+  tx:
+    min-frequency: 915000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 919500000
+  rssi-offset: -166
+clock-source: 1

--- a/AU_915_928_FSB_4.yml
+++ b/AU_915_928_FSB_4.yml
@@ -1,0 +1,51 @@
+band-id: AU_915_928
+uplink-channels:
+- frequency: 920000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 920200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 920400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 920600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 920800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 921000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 921200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 921400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+lora-standard-channel:
+  frequency: 920700000
+  data-rate: 12
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 920400000
+  rssi-offset: -166
+  tx:
+    min-frequency: 915000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 921100000
+  rssi-offset: -166
+clock-source: 1

--- a/AU_915_928_FSB_5.yml
+++ b/AU_915_928_FSB_5.yml
@@ -1,0 +1,51 @@
+band-id: AU_915_928
+uplink-channels:
+- frequency: 921600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 921800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 922000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 922200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 922400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 922600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 922800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 923000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+lora-standard-channel:
+  frequency: 922300000
+  data-rate: 12
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 922000000
+  rssi-offset: -166
+  tx:
+    min-frequency: 915000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 922700000
+  rssi-offset: -166
+clock-source: 1

--- a/AU_915_928_FSB_7.yml
+++ b/AU_915_928_FSB_7.yml
@@ -1,0 +1,51 @@
+band-id: AU_915_928
+uplink-channels:
+- frequency: 924800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 925000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 925200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 925400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 925600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 925800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 926000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 926200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+lora-standard-channel:
+  frequency: 925500000
+  data-rate: 12
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 925200000
+  rssi-offset: -166
+  tx:
+    min-frequency: 915000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 925900000
+  rssi-offset: -166
+clock-source: 1

--- a/AU_915_928_FSB_8.yml
+++ b/AU_915_928_FSB_8.yml
@@ -1,0 +1,51 @@
+band-id: AU_915_928
+uplink-channels:
+- frequency: 926400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 926600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 926800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 927000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 927200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 927400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 927600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 927800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+lora-standard-channel:
+  frequency: 927100000
+  data-rate: 12
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 926800000
+  rssi-offset: -166
+  tx:
+    min-frequency: 915000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 927500000
+  rssi-offset: -166
+clock-source: 1

--- a/US_902_928_FSB_3.yml
+++ b/US_902_928_FSB_3.yml
@@ -1,0 +1,55 @@
+band-id: US_902_928
+uplink-channels:
+- frequency: 905500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 905700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 905900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 906100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 906300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 906500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 906700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 906900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+lora-standard-channel:
+  frequency: 906200000
+  data-rate: 12
+  radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 905900000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 906600000
+  rssi-offset: -166
+clock-source: 1

--- a/US_902_928_FSB_4.yml
+++ b/US_902_928_FSB_4.yml
@@ -1,0 +1,55 @@
+band-id: US_902_928
+uplink-channels:
+- frequency: 907100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 907300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 907500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 907700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 907900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 908100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 908300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 908500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+lora-standard-channel:
+  frequency: 907800000
+  data-rate: 12
+  radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 907500000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 908200000
+  rssi-offset: -166
+clock-source: 1

--- a/US_902_928_FSB_5.yml
+++ b/US_902_928_FSB_5.yml
@@ -1,0 +1,55 @@
+band-id: US_902_928
+uplink-channels:
+- frequency: 908700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 908900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 909100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 909300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 909500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 909700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 909900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 910100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+lora-standard-channel:
+  frequency: 909400000
+  data-rate: 12
+  radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 909100000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 909800000
+  rssi-offset: -166
+clock-source: 1

--- a/US_902_928_FSB_6.yml
+++ b/US_902_928_FSB_6.yml
@@ -1,0 +1,55 @@
+band-id: US_902_928
+uplink-channels:
+- frequency: 910300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 910500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 910700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 910900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 911100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 911300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 911500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 911700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+lora-standard-channel:
+  frequency: 911000000
+  data-rate: 12
+  radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 910700000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 911400000
+  rssi-offset: -166
+clock-source: 1

--- a/US_902_928_FSB_7.yml
+++ b/US_902_928_FSB_7.yml
@@ -1,0 +1,55 @@
+band-id: US_902_928
+uplink-channels:
+- frequency: 911900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 912100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 912300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 912500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 912700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 912900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 913100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 913300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+lora-standard-channel:
+  frequency: 912600000
+  data-rate: 12
+  radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 912300000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 913000000
+  rssi-offset: -166
+clock-source: 1

--- a/US_902_928_FSB_8.yml
+++ b/US_902_928_FSB_8.yml
@@ -1,0 +1,55 @@
+band-id: US_902_928
+uplink-channels:
+- frequency: 913500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 913700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 913900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 914100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 914300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 914500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 914700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 914900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+lora-standard-channel:
+  frequency: 914200000
+  data-rate: 12
+  radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 913900000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 914600000
+  rssi-offset: -166
+clock-source: 1

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -27,6 +27,48 @@
   country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
   file: US_902_928_FSB_2.yml
 
+- id: US_902_928_FSB_3
+  name: United States 902-928 MHz, FSB 3
+  description: Default frequency plan for the United States and Canada, using sub-band 3
+  base-frequency: 915
+  country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
+  file: US_902_928_FSB_3.yml
+
+- id: US_902_928_FSB_4
+  name: United States 902-928 MHz, FSB 4
+  description: Default frequency plan for the United States and Canada, using sub-band 4
+  base-frequency: 915
+  country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
+  file: US_902_928_FSB_4.yml
+
+- id: US_902_928_FSB_5
+  name: United States 902-928 MHz, FSB 5
+  description: Default frequency plan for the United States and Canada, using sub-band 5
+  base-frequency: 915
+  country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
+  file: US_902_928_FSB_5.yml
+
+- id: US_902_928_FSB_6
+  name: United States 902-928 MHz, FSB 6
+  description: Default frequency plan for the United States and Canada, using sub-band 6
+  base-frequency: 915
+  country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
+  file: US_902_928_FSB_6.yml
+
+- id: US_902_928_FSB_7
+  name: United States 902-928 MHz, FSB 7
+  description: Default frequency plan for the United States and Canada, using sub-band 7
+  base-frequency: 915
+  country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
+  file: US_902_928_FSB_7.yml
+
+- id: US_902_928_FSB_8
+  name: United States 902-928 MHz, FSB 8
+  description: Default frequency plan for the United States and Canada, using sub-band 8
+  base-frequency: 915
+  country-codes: [bo, ca, co, cr, do, ec, gy, mx, pa, py, pe, pr, sr, us, uy, ve]
+  file: US_902_928_FSB_8.yml
+
 - id: AU_915_928_FSB_1
   name: Australia 915-928 MHz, FSB 1
   description: Default frequency plan for Australia, using sub-band 1
@@ -41,12 +83,47 @@
   country-codes: [br, cl, nz, ar, au]
   file: AU_915_928_FSB_2.yml
 
+- id: AU_915_928_FSB_3
+  name: Australia 915-928 MHz, FSB 3
+  description: Default frequency plan for Australia, u3ing sub-band 3
+  base-frequency: 915
+  country-codes: [br, cl, nz, ar, au]
+  file: AU_915_928_FSB_3.yml
+
+- id: AU_915_928_FSB_4
+  name: Australia 915-928 MHz, FSB 4
+  description: Default frequency plan for Australia, using sub-band 4
+  base-frequency: 915
+  country-codes: [br, cl, nz, ar, au]
+  file: AU_915_928_FSB_4.yml
+
+- id: AU_915_928_FSB_5
+  name: Australia 915-928 MHz, FSB 5
+  description: Default frequency plan for Australia, using sub-band 5
+  base-frequency: 915
+  country-codes: [br, cl, nz, ar, au]
+  file: AU_915_928_FSB_5.yml
+
 - id: AU_915_928_FSB_6
   name: Australia 915-928 MHz, FSB 6
   description: Frequency plan for Australia, using sub-band 6, which overlaps with Asia 923-925 MHz
   base-frequency: 915
   country-codes: [br, cl, nz, ar, au]
   file: AU_915_928_FSB_6.yml
+
+- id: AU_915_928_FSB_7
+  name: Australia 915-928 MHz, FSB 7
+  description: Default frequency plan for Australia, using sub-band 7
+  base-frequency: 915
+  country-codes: [br, cl, nz, ar, au]
+  file: AU_915_928_FSB_7.yml
+
+- id: AU_915_928_FSB_8
+  name: Australia 915-928 MHz, FSB 8
+  description: Default frequency plan for Australia, using sub-band 8
+  base-frequency: 915
+  country-codes: [br, cl, nz, ar, au]
+  file: AU_915_928_FSB_8.yml
 
 - id: CN_470_510_FSB_11
   name: China 470-510 MHz, FSB 11


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds the missing FSBs for US915 (3-8) and AU915 (3-5 and 7-8).

Closes #24

#### Changes
<!-- What are the changes made in this pull request? -->

- Basically copy-paste FSB n and add 1.6 MHz to the frequencies.

#### Notes for Reviewers

- @benolayinka please confirm that the `country-codes` that you added apply to all FSBs.
- I have not tested the changes. In the worst case I messed up a copy-paste.
- @benolayinka please see if anything needs to be documented.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
