### PR TITLE
Add EU_433 frequency plan

### DIFF
--- a/EU_433.yml
+++ b/EU_433.yml
@@ -1,0 +1,81 @@
+band-id: EU_433
+sub-bands:
+- min-frequency: 433050000
+  max-frequency: 434790000
+  duty-cycle: 0.1 # NOTE: ETSI EN300220 limit is 10%; LoRaWAN limit for end-devices is 1%
+  max-eirp: 12.15
+uplink-channels:
+- frequency: 433175000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 433375000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 433575000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 433775000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 433975000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 434175000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 434375000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 434575000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+downlink-channels:
+- frequency: 433175000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 433375000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 433575000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 433775000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 433975000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 434175000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 434375000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 434575000
+  min-data-rate: 0
+  max-data-rate: 5
+lora-standard-channel:
+  frequency: 434075000
+  data-rate: 6
+  radio: 1
+radios:
+- enable: true
+  chip-type: SX1255
+  frequency: 433475000
+  rssi-offset: -176
+  tx:
+    min-frequency: 433050000
+    max-frequency: 434790000
+- enable: true
+  chip-type: SX1255
+  frequency: 434275000
+  rssi-offset: -176
+clock-source: 1

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -13,6 +13,12 @@
   country-codes: [al, ad, ao, at, bh, be, ba, bw, bg, cg, hr, cy, cz, dk, ee, sz, fi, fr, gr, hu, is, ie, it, lv, ls, li, lt, lu, mg, mw, mt, mu, md, me, mz, na, nl, mk, ph, pl, pt, ro, ru, sa, rs, sc, sk, si, za, es, se, ch, tz, tr, ae, gb, va, zm, zw]
   file: EU_863_870_TTN.yml
 
+- id: EU_433
+  name: Europe 433 MHz (ITU region 1)
+  description: Default frequency plan for worldwide 433MHz
+  base-frequency: 433
+  file: EU_433.yml
+
 - id: US_902_928_FSB_1
   name: United States 902-928 MHz, FSB 1
   description: Default frequency plan for the United States and Canada, using sub-band 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds the EU 433 frequency plan

Closes #17

The min/max frequencies in the the sub-band and radio come from the Regional Parameters 1.0.2 specification:

```
652 EU433 end-devices should be capable of operating in the 433.05 to 434.79 MHz frequency
653 band
```

Then we start with the channels:

```
649 The LoRaWAN channels center frequency can be in the following range:
650 * Minimum frequency : 433.175 MHz
651 * Maximum frequency : 434.665 MHz
...
656 The first three channels correspond to 433.175, 433.375 and 433.575 MHz with DR0 to DR5
```

And after that, we just continue with the same spacing.

I've placed the 250kHz channel at 434.075 MHz, since we've seen some 250kHz uplinks at that frequency in the past, so there seem to be some gateways out there that listen on this frequency.

I've configured the radios to listen at the center of the 4 channels they're responsible for.

I've taken the `chip-type: SX1255` and `rssi-offset: -176` from the CN470 plan, since I assume that EU433 uses the same chip.

![EU_433 yml](https://user-images.githubusercontent.com/181308/113010642-4a62ee80-9179-11eb-80bd-794c68f75dd0.png)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
