### PR TITLE
Add AS923 Group 2, 3 and 4 (compatibility) plans

### DIFF
--- a/AS_923_2.yml
+++ b/AS_923_2.yml
@@ -1,24 +1,24 @@
 band-id: AS_923
 uplink-channels:
-- frequency: 923200000
+- frequency: 921400000
   min-data-rate: 0
   max-data-rate: 5
   radio: 0
-- frequency: 923400000
+- frequency: 921600000
   min-data-rate: 0
   max-data-rate: 5
   radio: 0
 downlink-channels:
-- frequency: 923200000
+- frequency: 921400000
   min-data-rate: 0
   max-data-rate: 5
-- frequency: 923400000
+- frequency: 921600000
   min-data-rate: 0
   max-data-rate: 5
 radios:
 - enable: true
   chip-type: SX1257
-  frequency: 923300000
+  frequency: 921500000
   rssi-offset: -166
   tx:
     min-frequency: 915000000

--- a/AS_923_2.yml
+++ b/AS_923_2.yml
@@ -1,4 +1,4 @@
-band-id: AS_923
+band-id: AS_923_2
 uplink-channels:
 - frequency: 921400000
   min-data-rate: 0

--- a/AS_923_3.yml
+++ b/AS_923_3.yml
@@ -1,24 +1,24 @@
 band-id: AS_923
 uplink-channels:
-- frequency: 923200000
+- frequency: 916600000
   min-data-rate: 0
   max-data-rate: 5
   radio: 0
-- frequency: 923400000
+- frequency: 916800000
   min-data-rate: 0
   max-data-rate: 5
   radio: 0
 downlink-channels:
-- frequency: 923200000
+- frequency: 916600000
   min-data-rate: 0
   max-data-rate: 5
-- frequency: 923400000
+- frequency: 916800000
   min-data-rate: 0
   max-data-rate: 5
 radios:
 - enable: true
   chip-type: SX1257
-  frequency: 923300000
+  frequency: 916700000
   rssi-offset: -166
   tx:
     min-frequency: 915000000

--- a/AS_923_3.yml
+++ b/AS_923_3.yml
@@ -1,4 +1,4 @@
-band-id: AS_923
+band-id: AS_923_3
 uplink-channels:
 - frequency: 916600000
   min-data-rate: 0

--- a/AS_923_4.yml
+++ b/AS_923_4.yml
@@ -1,24 +1,24 @@
 band-id: AS_923
 uplink-channels:
-- frequency: 923200000
+- frequency: 917300000
   min-data-rate: 0
   max-data-rate: 5
   radio: 0
-- frequency: 923400000
+- frequency: 917500000
   min-data-rate: 0
   max-data-rate: 5
   radio: 0
 downlink-channels:
-- frequency: 923200000
+- frequency: 917300000
   min-data-rate: 0
   max-data-rate: 5
-- frequency: 923400000
+- frequency: 917500000
   min-data-rate: 0
   max-data-rate: 5
 radios:
 - enable: true
   chip-type: SX1257
-  frequency: 923300000
+  frequency: 917400000
   rssi-offset: -166
   tx:
     min-frequency: 915000000

--- a/AS_923_4.yml
+++ b/AS_923_4.yml
@@ -1,4 +1,4 @@
-band-id: AS_923
+band-id: AS_923_4
 uplink-channels:
 - frequency: 917300000
   min-data-rate: 0

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -148,11 +148,28 @@
   file: lbt_80_over_128.yml
 
 - id: AS_923
-  name: Asia 923 MHz with only default channels
-  description: TTN Community Network frequency plan for Asian countries, using default frequencies of the AS923 band. This is added only for compatibility. Preferrably use the 920-923 or 923-925 variants
+  name: Asia 915–928 MHz (AS923 Group 1) with only default channels
+  description: Compatibility frequency plan for Asian countries with common channels in the 923.0-923.5 MHz sub-band
   base-frequency: 915
-  country-codes: [au, bo, bn, cl, kh, hk, id, la, tw, th, ve, vn, my, nz, sg, sr, py, pe, uy]
   file: AS_923.yml
+
+- id: AS_923_2
+  name: Asia 920-923 MHz (AS923 Group 2) with only default channels
+  description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band
+  base-frequency: 915
+  file: AS_923_2.yml
+
+- id: AS_923_3
+  name: Asia 915–921 MHz (AS923 Group 3) with only default channels
+  description: Compatibility frequency plan for Asian countries with common channels in the 916.5-917.0 MHz sub-band
+  base-frequency: 915
+  file: AS_923_3.yml
+
+- id: AS_923_4
+  name: Asia 917–920 MHz (AS923 Group 4) with only default channels
+  description: Compatibility frequency plan for Asian countries with common channels in the 917.3-917.5 MHz sub-band
+  base-frequency: 915
+  file: AS_923_4.yml
 
 - id: AS_923_925
   name: Asia 923-925 MHz


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds the AS923 (Group 2) and (Group 3) plans with only the 2 mandatory channels.

From the spec:

```
1357 The network channels can be freely assigned by the network operator. However, the two
1358 following default channels SHALL be implemented in every AS923 end-device. Those
1359 channels are the minimum set that all network gateways SHALL always be listening on.
1360 | Modulation | Bandwidth [kHz] | Channel Frequency [Hz]           | LoRa DR / Bitrate
     |            |                 | 923200000 + AS923_FREQ_OFFSET_HZ |
     | LoRa       | 125             |                                  | DR0 to DR5 / 0.3-5 kbps
     |            |                 | 923400000 + AS923_FREQ_OFFSET_HZ |
```

```
1486 Group AS923-1: AS923_FREQ_OFFSET default value = 0x00000000, 
1487 AS923_FREQ_OFFSET_HZ = 0 .0 MHz
1488 This group is composed of countries having available frequencies in the 915 – 928 
1489 MHz range with common channels in the 923.0 – 923.5 MHz sub-band. These are the 
1490 “historical” AS923 countries, compliant to RP2-1.0.0 specification and previous 
1491 versions.
```

```
1492 Group AS923-2: AS923_FREQ_OFFSET default value = 0xFFFFB9B0, 
1493 AS923_FREQ_OFFSET_HZ = -1.80 MHz
1494 This group is composed of countries having available frequencies in the 920 – 923 
1495 MHz range with common channels in the 921.4 – 922.0 MHz sub-band.
```

```
1496 Group AS923-3: AS923_FREQ_OFFSET default value = 0xFFFEFE30, 
1497 AS923_FREQ_OFFSET_HZ = -6.60 MHz
1498 This group is composed of countries having available frequencies in the 915 – 921 
1499 MHz range with common channels in the 916.5 – 917.0 MHz sub-band.
```

They're based on the existing AS923 compatibility plan, so they'll look quite similar.

![AS_923 yml](https://user-images.githubusercontent.com/181308/113147420-0cc19c80-9231-11eb-9e24-66ca0fa1d3d6.png)

![AS_923_2 yml](https://user-images.githubusercontent.com/181308/113147494-1ea33f80-9231-11eb-8162-a925139cff1e.png)

![AS_923_3 yml](https://user-images.githubusercontent.com/181308/113147515-2367f380-9231-11eb-941d-dfbcbb8bb206.png)

From the 1.0.3 spec, we additionally add the `AS923-4` group:

```
1499 Group AS923-4: AS923_FREQ_OFFSET default value = 0xFFFF1988, 
1500 AS923_FREQ_OFFSET_HZ = -5.90 MHz
1501 This group is composed of countries having available frequencies in the 917 – 920
1502 MHz range with common channels in the 917.3 – 917.5 MHz sub-band.
```

![AS_923_4 yml](https://user-images.githubusercontent.com/181308/120311265-95af8f80-c2d7-11eb-9683-d58f894b595d.png)

---

We still need to determine to which countries each of these apply.