### PR TITLE
Add AS_920_923 Japanese plan

### DIFF
--- a/AS_920_923_JP_DwellTime.yml
+++ b/AS_920_923_JP_DwellTime.yml
@@ -1,0 +1,4 @@
+dwell-time:
+  uplinks: true
+  downlinks: true
+  duration: 400ms

--- a/AS_920_923_JP_Optional.yml
+++ b/AS_920_923_JP_Optional.yml
@@ -1,0 +1,88 @@
+band-id: AS_920_923_JP_Optional
+sub-bands:
+  - min-frequency: 920600000
+    max-frequency: 922000000
+    max-eirp: 16
+uplink-channels:
+  - frequency: 920600000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+  - frequency: 920800000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+  - frequency: 921000000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+  - frequency: 921200000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+  - frequency: 921400000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+  - frequency: 921600000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+  - frequency: 921800000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+  - frequency: 922000000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+downlink-channels:
+  - frequency: 920600000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 920800000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 921000000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 921200000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 921400000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 921600000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 921800000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 922000000
+    min-data-rate: 0
+    max-data-rate: 5
+lora-standard-channel:
+  frequency: 922100000
+  data-rate: 6
+  radio: 1
+fsk-channel:
+  frequency: 922700000
+  data-rate: 7
+  radio: 1
+radios:
+  - enable: true
+    chip-type: SX1257
+    frequency: 920900000
+    rssi-offset: -166
+    tx:
+      min-frequency: 920600000
+      max-frequency: 922000000
+  - enable: true
+    chip-type: SX1257
+    frequency: 921700000
+    rssi-offset: -166
+clock-source: 1
+listen-before-talk:
+  rssi-offset: -4
+  rssi-target: -80
+  scan-time: 128000

--- a/AS_920_923_JP_Optional.yml
+++ b/AS_920_923_JP_Optional.yml
@@ -1,66 +1,66 @@
 band-id: AS_920_923_JP_Optional
 sub-bands:
-  - min-frequency: 920600000
-    max-frequency: 922000000
-    max-eirp: 16
+- min-frequency: 920600000
+  max-frequency: 922000000
+  max-eirp: 16
 uplink-channels:
-  - frequency: 920600000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 0
-  - frequency: 920800000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 0
-  - frequency: 921000000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 0
-  - frequency: 921200000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 0
-  - frequency: 921400000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 1
-  - frequency: 921600000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 1
-  - frequency: 921800000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 1
-  - frequency: 922000000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 1
+- frequency: 920600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 920800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 921000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 921200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 921400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 921600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 921800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 922000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
 downlink-channels:
-  - frequency: 920600000
-    min-data-rate: 0
-    max-data-rate: 5
-  - frequency: 920800000
-    min-data-rate: 0
-    max-data-rate: 5
-  - frequency: 921000000
-    min-data-rate: 0
-    max-data-rate: 5
-  - frequency: 921200000
-    min-data-rate: 0
-    max-data-rate: 5
-  - frequency: 921400000
-    min-data-rate: 0
-    max-data-rate: 5
-  - frequency: 921600000
-    min-data-rate: 0
-    max-data-rate: 5
-  - frequency: 921800000
-    min-data-rate: 0
-    max-data-rate: 5
-  - frequency: 922000000
-    min-data-rate: 0
-    max-data-rate: 5
+- frequency: 920600000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 920800000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 921000000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 921200000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 921400000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 921600000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 921800000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 922000000
+  min-data-rate: 0
+  max-data-rate: 5
 lora-standard-channel:
   frequency: 922100000
   data-rate: 6
@@ -70,19 +70,19 @@ fsk-channel:
   data-rate: 7
   radio: 1
 radios:
-  - enable: true
-    chip-type: SX1257
-    frequency: 920900000
-    rssi-offset: -166
-    tx:
-      min-frequency: 920600000
-      max-frequency: 922000000
-  - enable: true
-    chip-type: SX1257
-    frequency: 921700000
-    rssi-offset: -166
+- enable: true
+  chip-type: SX1257
+  frequency: 920900000
+  rssi-offset: -166
+  tx:
+    min-frequency: 920600000
+    max-frequency: 922000000
+- enable: true
+  chip-type: SX1257
+  frequency: 921700000
+  rssi-offset: -166
 clock-source: 1
 listen-before-talk:
   rssi-offset: -4
   rssi-target: -80
-  scan-time: 128000
+  scan-time: 5000000

--- a/AS_920_923_JP_Separate.yml
+++ b/AS_920_923_JP_Separate.yml
@@ -1,0 +1,88 @@
+band-id: AS_920_923_JP_Separate
+sub-bands:
+- min-frequency: 920600000
+  max-frequency: 923400000
+  max-eirp: 16
+uplink-channels:
+- frequency: 923200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 923400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 922800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 923000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 920600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 920800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 921000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 921200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+downlink-channels:
+- frequency: 923200000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 923400000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 922800000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 923000000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 920600000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 920800000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 921000000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 921200000
+  min-data-rate: 0
+  max-data-rate: 5
+lora-standard-channel:
+  frequency: 922100000
+  data-rate: 6
+  radio: 1
+fsk-channel:
+  frequency: 922700000
+  data-rate: 7
+  radio: 1
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 920900000
+  rssi-offset: -166
+  tx:
+    min-frequency: 920600000
+    max-frequency: 923400000
+- enable: true
+  chip-type: SX1257
+  frequency: 923100000
+  rssi-offset: -166
+clock-source: 1
+listen-before-talk:
+  rssi-offset: -4
+  rssi-target: -80
+  scan-time: 128000

--- a/AS_920_923_JP_Separate.yml
+++ b/AS_920_923_JP_Separate.yml
@@ -85,4 +85,4 @@ clock-source: 1
 listen-before-talk:
   rssi-offset: -4
   rssi-target: -80
-  scan-time: 128000
+  scan-time: 5000000

--- a/AS_920_923_JP_Standard.yml
+++ b/AS_920_923_JP_Standard.yml
@@ -1,6 +1,6 @@
 band-id: AS_920_923_JP_Standard
 sub-bands:
-- min-frequency: 920600000
+- min-frequency: 922000000
   max-frequency: 923400000
   max-eirp: 16
 uplink-channels:
@@ -85,4 +85,4 @@ clock-source: 1
 listen-before-talk:
   rssi-offset: -4
   rssi-target: -80
-  scan-time: 128000
+  scan-time: 5000000

--- a/AS_920_923_JP_Standard.yml
+++ b/AS_920_923_JP_Standard.yml
@@ -1,0 +1,88 @@
+band-id: AS_920_923_JP_Standard
+sub-bands:
+- min-frequency: 920600000
+  max-frequency: 923400000
+  max-eirp: 16
+uplink-channels:
+- frequency: 923200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 923400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 922800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 923000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 922000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 922200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 922400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 922600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+downlink-channels:
+- frequency: 923200000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 923400000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 922800000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 923000000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 922000000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 922200000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 922400000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 922600000
+  min-data-rate: 0
+  max-data-rate: 5
+lora-standard-channel:
+  frequency: 922100000
+  data-rate: 6
+  radio: 1
+fsk-channel:
+  frequency: 921800000
+  data-rate: 7
+  radio: 1
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 922500000
+  rssi-offset: -166
+  tx:
+    min-frequency: 922000000
+    max-frequency: 923400000
+- enable: true
+  chip-type: SX1257
+  frequency: 923100000
+  rssi-offset: -166
+clock-source: 1
+listen-before-talk:
+  rssi-offset: -4
+  rssi-target: -80
+  scan-time: 128000

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -161,6 +161,20 @@
   country-codes: [jp, my, sg]
   file: lbt_80_over_128.yml
 
+- id: AS_920_923_JP_Standard
+  name: Japan 920-923 MHz with LBT
+  description: Frequency plan for Japan, using frequencies ≤ 923 MHz with LBT
+  base-frequency: 915
+  country-codes: [jp]
+  file: AS_920_923_JP_Standard.yml
+
+- id: AS_920_923_JP_Separate
+  name: Japan 920-923 MHz with LBT
+  description: Frequency plan for Japan, using frequencies ≤ 923 MHz with LBT
+  base-frequency: 915
+  country-codes: [jp]
+  file: AS_920_923_JP_Separate.yml
+
 - id: AS_923
   name: Asia 923 MHz with only default channels
   description: TTN Community Network frequency plan for Asian countries, using default frequencies of the AS923 band. This is added only for compatibility. Preferrably use the 920-923 or 923-925 variants

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -168,12 +168,28 @@
   country-codes: [jp]
   file: AS_920_923_JP_Standard.yml
 
+- id: AS_920_923_JP_Standard_DwellTime
+  name: Japan 920-923 MHz with LBT, DwellTime
+  description: Frequency plan for Japan, using frequencies ≤ 923 MHz with LBT, DwellTime
+  base-frequency: 915
+  base-id: AS_920_923_JP_Standard
+  country-codes: [jp]
+  file: AS_920_923_JP_DwellTime.yml
+
 - id: AS_920_923_JP_Separate
   name: Japan 920-923 MHz with LBT
   description: Frequency plan for Japan, using frequencies ≤ 923 MHz with LBT
   base-frequency: 915
   country-codes: [jp]
   file: AS_920_923_JP_Separate.yml
+
+- id: AS_920_923_JP_Separate_DwellTime
+  name: Japan 920-923 MHz with LBT, DwellTime
+  description: Frequency plan for Japan, using frequencies ≤ 923 MHz with LBT, DwellTime
+  base-frequency: 915
+  base-id: AS_920_923_JP_Separate
+  country-codes: [jp]
+  file: AS_920_923_JP_DwellTime.yml
 
 - id: AS_923
   name: Asia 923 MHz with only default channels

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -191,6 +191,21 @@
   country-codes: [jp]
   file: AS_920_923_JP_DwellTime.yml
 
+- id: AS_920_923_JP_Optional
+  name: Japan 920-923 MHz with LBT
+  description: Frequency plan for Japan 16ch, using frequencies ≤ 923 MHz with LBT
+  base-frequency: 915
+  country-codes: [jp]
+  file: AS_920_923_JP_Optional.yml
+
+- id: AS_920_923_JP_Optional_DwellTime
+  name: Japan 920-923 MHz with LBT, DwellTime
+  description: Frequency plan for Japan 16ch, using frequencies ≤ 923 MHz with LBT, DwellTime
+  base-frequency: 915
+  base-id: AS_920_923_JP_Optional
+  country-codes: [jp]
+  file: AS_920_923_JP_DwellTime.yml
+
 - id: AS_923
   name: Asia 923 MHz with only default channels
   description: TTN Community Network frequency plan for Asian countries, using default frequencies of the AS923 band. This is added only for compatibility. Preferrably use the 920-923 or 923-925 variants


### PR DESCRIPTION
#### Summary
Add Japanese specific plan for AS923.
Using from 920.6MHz to 923.4MHz with LBT.


#### Changes
Currently  [AS920-923 with LBT](https://github.com/TheThingsNetwork/lorawan-frequency-plans/blob/master/AS_920_923.yml) is incorrect in Japan.
Because the Japanese law [ARIB-STD-T108](http://www.arib.or.jp/english/html/overview/doc/5-STD-T108v1_3-E1.pdf)  need that LBT scan time is below:

* 128usec or more for 922.4MHz-923.4MHz
* 5msec or more for 920.6MHz-922.2MHz.

So we would like to use AS920-923 with 5msec scan time.
And also we would like to use three patterns as below:

* 920.6MHz-921.2MHz(4ch) and 922.8MHz-923.4MHz(4ch)
* 922.0MHz-923.4MHz(8ch) 
* 920.6MHz-922.0MHz(8ch)

The last plan is for 16ch gateway, is only used with second plan.

#### about ARIB-STD-T108 
The low power regulations is from page 33.
The frequencies for 20mW or less are described from page 50.

see attached ![table1](https://user-images.githubusercontent.com/10464428/121863848-3cb01480-cd37-11eb-8010-86eb570f0615.jpg) and
![table2](https://user-images.githubusercontent.com/10464428/121863859-3e79d800-cd37-11eb-9b4b-e1c1a0b90c12.jpg)

#### Notes for Reviewers

* We would like to use 128usec scan time for 922.4MHz or upper, but TTSC denies that frequency specific scan time. So we can't use 128usec scan time. (note) The Kerlink gateways allow frequency specific scan time. 

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [x] Documentation: Relevant documentation is added or updated.
