### PR TITLE
Disable dwell time for AS923 plans in Australia

### DIFF
--- a/AS_920_923_TTN_AU.yml
+++ b/AS_920_923_TTN_AU.yml
@@ -2,4 +2,7 @@ sub-bands:
 - min-frequency: 915000000
   max-frequency: 928000000
   duty-cycle: 1
+dwell-time:
+  uplinks: false
+  downlinks: false
 max-eirp: 30

--- a/AS_923_925_TTN_AU.yml
+++ b/AS_923_925_TTN_AU.yml
@@ -2,4 +2,7 @@ sub-bands:
 - min-frequency: 915000000
   max-frequency: 928000000
   duty-cycle: 1
+dwell-time:
+  uplinks: false
+  downlinks: false
 max-eirp: 30


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/506

#### Changes
<!-- What are the changes made in this pull request? -->

This explicitly disables dwell time for AS923 plans used in Australia.

AS923 supports dwell time, but a `TxParamSetupReq` with dwell time instruction is only sent by the Network Server when dwell time is explicitly configured in the frequency plan or in the end device.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
