### PR TITLE
Add EU_863_870_MNP plan

### DIFF
--- a/EU_863_870_MNP.yml
+++ b/EU_863_870_MNP.yml
@@ -1,0 +1,79 @@
+band-id: EU_863_870
+uplink-channels:
+  - frequency: 868100000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+  - frequency: 868300000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+  - frequency: 868500000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+  - frequency: 868700000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+  - frequency: 868900000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+  - frequency: 869100000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+  - frequency: 869300000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+  - frequency: 869500000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 0
+downlink-channels:
+  - frequency: 868100000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 868300000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 868500000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 868700000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 868900000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 869100000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 869300000
+    min-data-rate: 0
+    max-data-rate: 5
+  - frequency: 869500000
+    min-data-rate: 0
+    max-data-rate: 5
+lora-standard-channel:
+  frequency: 868300000
+  data-rate: 6
+  radio: 1
+fsk-channel:
+  frequency: 868800000
+  data-rate: 7
+  radio: 1
+radios:
+  - enable: true
+    chip-type: SX1257
+    frequency: 869100000
+    rssi-offset: -166
+    tx:
+      min-frequency: 863000000
+      max-frequency: 870000000
+  - enable: true
+    chip-type: SX1257
+    frequency: 868500000
+    rssi-offset: -166

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -1,12 +1,12 @@
 - id: EU_863_870
-  name: Europe 863-870 MHz (SF12 for RX2)
+  name: Europe 863-870 MHz (overlap with TTN)
   description: Default frequency plan for Europe
   base-frequency: 868
   country-codes: [al, ad, ao, at, bh, be, ba, bw, bg, cg, hr, cy, cz, dk, ee, sz, fi, fr, gr, hu, is, ie, it, lv, ls, li, lt, lu, mg, mw, mt, mu, md, me, mz, na, nl, mk, ph, pl, pt, ro, ru, sa, rs, sc, sk, si, za, es, se, ch, tz, tr, ae, gb, va, zm, zw]
   file: EU_863_870.yml
 
 - id: EU_863_870_TTN
-  name: Europe 863-870 MHz (SF9 for RX2 - recommended)
+  name: Europe 863-870 MHz (SF9 for RX2, recommended for TTN)
   description: TTN Community Network frequency plan for Europe, using SF9 for RX2
   base-frequency: 868
   base-id: EU_863_870
@@ -14,12 +14,20 @@
   file: EU_863_870_TTN.yml
 
 - id: EU_863_870_ROAMING_DRAFT
-  name: Europe 863-870 MHz, 6 channels for roaming (Draft)
+  name: Europe 863-870 MHz, 6 channels for roaming (overlap with TTN)
   description: European 6 channel plan used by major operators to support LoRaWAN Passive Roaming
   base-frequency: 868
   base-id: EU_863_870
   country-codes: [al, ad, ao, at, bh, be, ba, bw, bg, cg, hr, cy, cz, dk, ee, sz, fi, fr, gr, hu, is, ie, it, lv, ls, li, lt, lu, mg, mw, mt, mu, md, me, mz, na, nl, mk, ph, pl, pt, ro, ru, sa, rs, sc, sk, si, za, es, se, ch, tz, tr, ae, gb, va, zm, zw]
   file: EU_863_870_ROAMING_DRAFT.yml
+
+- id: EU_863_870_MNP
+  name: Europe 863-870 MHz, 8 channels avoiding RFID (no overlap with TTN)
+  description: European 8 channel plan used to avoid RFID
+  base-frequency: 868
+  base-id: EU_863_870
+  country-codes: [al, ad, ao, at, bh, be, ba, bw, bg, cg, hr, cy, cz, dk, ee, sz, fi, fr, gr, hu, is, ie, it, lv, ls, li, lt, lu, mg, mw, mt, mu, md, me, mz, na, nl, mk, ph, pl, pt, ro, ru, sa, rs, sc, sk, si, za, es, se, ch, tz, tr, ae, gb, va, zm, zw]
+  file: EU_863_870_MNP.yml
 
 - id: EU_433
   name: Europe 433 MHz (ITU region 1)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/681

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

In short from the discussion on the referenced issue there is a interest in having a frequency plan that avoid the RFDI range.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add EU_863_870_MNP plan
- Update `frequency_plans.yml` with suggestion made by Johan on the discussion

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is currently as a draft due to the concern about the frequency  `869.3 MHz` not being permitted. More details can be found on the discussion and on page 25 of the [doc](https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
