### PR TITLE
Explicitly add the dwell time duration

### DIFF
--- a/enable_dwell_time_400ms.yml
+++ b/enable_dwell_time_400ms.yml
@@ -1,3 +1,4 @@
 dwell-time:
   uplinks: true
   downlinks: true
+  duration: 400ms

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -275,7 +275,7 @@
   description: Compatibility frequency plan for Asian countries with common channels in the 923.0-923.5 MHz sub-band and dwell time enabled
   base-frequency: 915
   base-id: AS_923
-  file: enable_dwell_time.yml
+  file: enable_dwell_time_400ms.yml
 
 - id: AS_923_2_NDT
   band-id: AS_923_2
@@ -291,7 +291,7 @@
   description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time enabled
   base-frequency: 915
   base-id: AS_923_2
-  file: enable_dwell_time.yml
+  file: enable_dwell_time_400ms.yml
 
 - id: AS_923_3_NDT
   band-id: AS_923_3
@@ -307,7 +307,7 @@
   description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time enabled
   base-frequency: 915
   base-id: AS_923_3
-  file: enable_dwell_time.yml
+  file: enable_dwell_time_400ms.yml
 
 - id: AS_923_4_NDT
   band-id: AS_923_4
@@ -323,7 +323,7 @@
   description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time enabled
   base-frequency: 915
   base-id: AS_923_4
-  file: enable_dwell_time.yml
+  file: enable_dwell_time_400ms.yml
 
 - id: AS_923_925
   band-id: AS_923_925


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-frequency-plans/pull/48

#### Changes
<!-- What are the changes made in this pull request? -->

- Explicitly add the dwell time _duration_ to the dwell time configuration while enabling the dwell time
  - From what regulations I could find about the AS923 countries, the 400ms duration was used everywhere
  - Should anyone stray away from this common value, we will fix it in a frequency plan dedicated to that country

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The lack of duration fails the validation:
https://github.com/TheThingsNetwork/lorawan-stack/blob/9d58a370c158a60072ed841370a5e7a97b67f419/pkg/frequencyplans/frequencyplans.go#L429-L431
During my tests I only verified that disabling works, which was not enough.

I will add CI checks as part of https://github.com/TheThingsNetwork/lorawan-frequency-plans/issues/38 which will catch these issues in the future.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
