### PR TITLE
Disable AU915-928 downlink dwell time

### DIFF
--- a/AU_915_928_FSB_1.yml
+++ b/AU_915_928_FSB_1.yml
@@ -36,6 +36,8 @@ lora-standard-channel:
   frequency: 915900000
   data-rate: 12
   radio: 0
+dwell-time:
+  downlinks: false
 radios:
 - enable: true
   chip-type: SX1257

--- a/AU_915_928_FSB_2.yml
+++ b/AU_915_928_FSB_2.yml
@@ -36,6 +36,8 @@ lora-standard-channel:
   frequency: 917500000
   data-rate: 12
   radio: 0
+dwell-time:
+  downlinks: false
 radios:
 - enable: true
   chip-type: SX1257

--- a/AU_915_928_FSB_3.yml
+++ b/AU_915_928_FSB_3.yml
@@ -36,6 +36,8 @@ lora-standard-channel:
   frequency: 919100000
   data-rate: 12
   radio: 0
+dwell-time:
+  downlinks: false
 radios:
 - enable: true
   chip-type: SX1257

--- a/AU_915_928_FSB_4.yml
+++ b/AU_915_928_FSB_4.yml
@@ -36,6 +36,8 @@ lora-standard-channel:
   frequency: 920700000
   data-rate: 12
   radio: 0
+dwell-time:
+  downlinks: false
 radios:
 - enable: true
   chip-type: SX1257

--- a/AU_915_928_FSB_5.yml
+++ b/AU_915_928_FSB_5.yml
@@ -36,6 +36,8 @@ lora-standard-channel:
   frequency: 922300000
   data-rate: 12
   radio: 0
+dwell-time:
+  downlinks: false
 radios:
 - enable: true
   chip-type: SX1257

--- a/AU_915_928_FSB_6.yml
+++ b/AU_915_928_FSB_6.yml
@@ -36,6 +36,8 @@ lora-standard-channel:
   frequency: 923900000
   data-rate: 12
   radio: 0
+dwell-time:
+  downlinks: false
 radios:
 - enable: true
   chip-type: SX1257

--- a/AU_915_928_FSB_7.yml
+++ b/AU_915_928_FSB_7.yml
@@ -36,6 +36,8 @@ lora-standard-channel:
   frequency: 925500000
   data-rate: 12
   radio: 0
+dwell-time:
+  downlinks: false
 radios:
 - enable: true
   chip-type: SX1257

--- a/AU_915_928_FSB_8.yml
+++ b/AU_915_928_FSB_8.yml
@@ -36,6 +36,8 @@ lora-standard-channel:
   frequency: 927100000
   data-rate: 12
   radio: 0
+dwell-time:
+  downlinks: false
 radios:
 - enable: true
   chip-type: SX1257

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @johanstokking @htdvisser
+* @johanstokking @adriansmares


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/5690

This PR fixes AU915-928 downlink dwell time behavior. Previously, as no dwell time was specified in the plan, the NS will automatically assert that downlink dwell time should be enabled. This is wrong per spec:

<img width="806" alt="image" src="https://user-images.githubusercontent.com/36161392/184363226-18d131d8-ce2e-40c5-b5f8-b3a4310d419a.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Explicitely disable downlink dwell time for AU915

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
