### PR TITLE
Feature/au915 fsb1 dwelltime off

### DIFF
--- a/AU_915_928_FSB_1_NDT.yml
+++ b/AU_915_928_FSB_1_NDT.yml
@@ -1,0 +1,54 @@
+band-id: AU_915_928
+uplink-channels:
+- frequency: 915200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 915400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 915600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 915800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 916000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 916200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 916400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 916600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+lora-standard-channel:
+  frequency: 915900000
+  data-rate: 12
+  radio: 0
+dwell-time:
+  uplinks: false
+  downlinks: false
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 915600000
+  rssi-offset: -166
+  tx:
+    min-frequency: 915000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 916300000
+  rssi-offset: -166
+clock-source: 1

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -159,6 +159,14 @@
   country-codes: [ar, au, bo, br, ca, cl, co, do, nz, py, pe, sr, uy]
   file: AU_915_928_FSB_8.yml
 
+- id: AU_915_928_FSB_1_NDT
+  band-id: AU_915_928
+  name: Australia 915-928 MHz, FSB 1
+  description: Default frequency plan for Australia, using sub-band 1 and dwell time disabled
+  base-frequency: 915
+  country-codes: [ar, au, bo, br, ca, cl, co, do, nz, py, pe, sr, uy]
+  file: AU_915_928_FSB_1_NDT.yml
+
 - id: CN_470_510_FSB_1
   band-id: CN_470_510
   name: China 470-510 MHz, FSB 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-frequency-plans/issues/55

#### Changes
<!-- What are the changes made in this pull request? -->

- Added AU915-928 FSB 1 variant with dwell time disabled (uplink and downlink)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
