### PR TITLE
Fix frequency plans for AS/JP

### DIFF
--- a/AS_920_923.yml
+++ b/AS_920_923.yml
@@ -78,6 +78,6 @@ radios:
     max-frequency: 923400000
 - enable: true
   chip-type: SX1257
-  frequency: 922000000
+  frequency: 922100000
   rssi-offset: -166
 clock-source: 1

--- a/AS_920_923_TTN_JP_1.yml
+++ b/AS_920_923_TTN_JP_1.yml
@@ -7,28 +7,16 @@ uplink-channels:
   - frequency: 923200000
     min-data-rate: 0
     max-data-rate: 5
-    radio: 1
+    radio: 0
   - frequency: 923400000
     min-data-rate: 0
     max-data-rate: 5
-    radio: 1
+    radio: 0
   - frequency: 922800000
     min-data-rate: 0
     max-data-rate: 5
-    radio: 1
+    radio: 0
   - frequency: 923000000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 1
-  - frequency: 922000000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 0
-  - frequency: 922200000
-    min-data-rate: 0
-    max-data-rate: 5
-    radio: 0
-  - frequency: 922400000
     min-data-rate: 0
     max-data-rate: 5
     radio: 0
@@ -36,6 +24,18 @@ uplink-channels:
     min-data-rate: 0
     max-data-rate: 5
     radio: 0
+  - frequency: 922000000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+  - frequency: 922200000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
+  - frequency: 922400000
+    min-data-rate: 0
+    max-data-rate: 5
+    radio: 1
 downlink-channels:
   - frequency: 923200000
     min-data-rate: 0
@@ -72,14 +72,14 @@ fsk-channel:
 radios:
   - enable: true
     chip-type: SX1257
-    frequency: 922500000
+    frequency: 923000000
     rssi-offset: -166
     tx:
       min-frequency: 922000000
       max-frequency: 923400000
   - enable: true
     chip-type: SX1257
-    frequency: 923100000
+    frequency: 922100000
     rssi-offset: -166
 clock-source: 1
 listen-before-talk:

--- a/AS_920_923_TTN_JP_2.yml
+++ b/AS_920_923_TTN_JP_2.yml
@@ -62,12 +62,8 @@ downlink-channels:
     min-data-rate: 0
     max-data-rate: 5
 lora-standard-channel:
-  frequency: 922100000
+  frequency: 923100000
   data-rate: 6
-  radio: 1
-fsk-channel:
-  frequency: 922700000
-  data-rate: 7
   radio: 1
 radios:
   - enable: true

--- a/AS_920_923_TTN_JP_3.yml
+++ b/AS_920_923_TTN_JP_3.yml
@@ -65,10 +65,6 @@ lora-standard-channel:
   frequency: 922100000
   data-rate: 6
   radio: 1
-fsk-channel:
-  frequency: 922700000
-  data-rate: 7
-  radio: 1
 radios:
   - enable: true
     chip-type: SX1257
@@ -79,7 +75,7 @@ radios:
       max-frequency: 922000000
   - enable: true
     chip-type: SX1257
-    frequency: 921700000
+    frequency: 921800000
     rssi-offset: -166
 clock-source: 1
 listen-before-talk:

--- a/AS_923_925.yml
+++ b/AS_923_925.yml
@@ -78,6 +78,6 @@ radios:
     max-frequency: 925000000
 - enable: true
   chip-type: SX1257
-  frequency: 924600000
+  frequency: 924500000
   rssi-offset: -166
 clock-source: 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #57 

In the plans for the AS/JP regions there are some discrepancies that this PR fixes. 

 - For `AS_920_923` the center frequency of `radio 1` has been shifted by .1 MHz so it defined bands fit nicely in the antenna's range.
![AS_920_923 yml](https://user-images.githubusercontent.com/19775528/201943940-11b93e91-c493-403e-be28-0f894e3cd0aa.png)

 - The same has been done for `AS_923_925`.
![AS_923_925 yml](https://user-images.githubusercontent.com/19775528/201944354-92c784de-38d2-4612-9f1c-740f9c305ab7.png)

 - `AS_920_923_TTN_JP_1` has been made to match the definition of `AS_920_923` as far as channel assignment and frequency goes.
![AS_920_923_TTN_JP_1 yml](https://user-images.githubusercontent.com/19775528/201944936-54ccfe6d-c780-4d2e-a72e-5a7d9d451328.png)

 - `AS_920_923_TTN_JP_2` has it's `FSK` channel removed as there is no more space for it in the frequency space, this follows the examples of `EU-433` and the `US`/`AU` bands. In addition the `standard` channel has been shifted so it falls nicely in the available frequency space.
![AS_920_923_TTN_JP_2 yml](https://user-images.githubusercontent.com/19775528/201945482-05600330-9dc1-4e60-9c77-1a799f328b00.png)

 - `AS_920_923_TTN_JP_3` underwent the same procedure as `AS_920_923_TTN_JP_2` except for the fact that the frequency of `radio 1` is shifted instead of the `standard` frequency.