### PR TITLE
Fix US915 and AU915 LoRa standard channel data rate

### DIFF
--- a/AU_915_928_FSB_1.yml
+++ b/AU_915_928_FSB_1.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 915900000
-  data-rate: 12
+  data-rate: 6
   radio: 0
 dwell-time:
   downlinks: false

--- a/AU_915_928_FSB_2.yml
+++ b/AU_915_928_FSB_2.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 917500000
-  data-rate: 12
+  data-rate: 6
   radio: 0
 dwell-time:
   downlinks: false

--- a/AU_915_928_FSB_3.yml
+++ b/AU_915_928_FSB_3.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 919100000
-  data-rate: 12
+  data-rate: 6
   radio: 0
 dwell-time:
   downlinks: false

--- a/AU_915_928_FSB_4.yml
+++ b/AU_915_928_FSB_4.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 920700000
-  data-rate: 12
+  data-rate: 6
   radio: 0
 dwell-time:
   downlinks: false

--- a/AU_915_928_FSB_5.yml
+++ b/AU_915_928_FSB_5.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 922300000
-  data-rate: 12
+  data-rate: 6
   radio: 0
 dwell-time:
   downlinks: false

--- a/AU_915_928_FSB_6.yml
+++ b/AU_915_928_FSB_6.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 923900000
-  data-rate: 12
+  data-rate: 6
   radio: 0
 dwell-time:
   downlinks: false

--- a/AU_915_928_FSB_7.yml
+++ b/AU_915_928_FSB_7.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 925500000
-  data-rate: 12
+  data-rate: 6
   radio: 0
 dwell-time:
   downlinks: false

--- a/AU_915_928_FSB_8.yml
+++ b/AU_915_928_FSB_8.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 927100000
-  data-rate: 12
+  data-rate: 6
   radio: 0
 dwell-time:
   downlinks: false

--- a/US_902_928_FSB_1.yml
+++ b/US_902_928_FSB_1.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 903000000
-  data-rate: 12
+  data-rate: 4
   radio: 0
 dwell-time:
   uplinks: true

--- a/US_902_928_FSB_2.yml
+++ b/US_902_928_FSB_2.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 904600000
-  data-rate: 12
+  data-rate: 4
   radio: 0
 dwell-time:
   uplinks: true

--- a/US_902_928_FSB_3.yml
+++ b/US_902_928_FSB_3.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 906200000
-  data-rate: 12
+  data-rate: 4
   radio: 0
 dwell-time:
   uplinks: true

--- a/US_902_928_FSB_4.yml
+++ b/US_902_928_FSB_4.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 907800000
-  data-rate: 12
+  data-rate: 4
   radio: 0
 dwell-time:
   uplinks: true

--- a/US_902_928_FSB_5.yml
+++ b/US_902_928_FSB_5.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 909400000
-  data-rate: 12
+  data-rate: 4
   radio: 0
 dwell-time:
   uplinks: true

--- a/US_902_928_FSB_6.yml
+++ b/US_902_928_FSB_6.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 911000000
-  data-rate: 12
+  data-rate: 4
   radio: 0
 dwell-time:
   uplinks: true

--- a/US_902_928_FSB_7.yml
+++ b/US_902_928_FSB_7.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 912600000
-  data-rate: 12
+  data-rate: 4
   radio: 0
 dwell-time:
   uplinks: true

--- a/US_902_928_FSB_8.yml
+++ b/US_902_928_FSB_8.yml
@@ -34,7 +34,7 @@ uplink-channels:
   radio: 1
 lora-standard-channel:
   frequency: 914200000
-  data-rate: 12
+  data-rate: 4
   radio: 0
 dwell-time:
   uplinks: true


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the data rate of the LoRa Standard Channel to be an uplink data rate instead of downlink data rate. The two indices encode an equivalent data rate, but for some reason we've encoded the downlink data rate instead of the uplink data rate in our frequency plans.


#### Changes
<!-- What are the changes made in this pull request? -->

- Use data rate index 12 instead of 4 for the LoRa Standard Channel in US915 and AU915.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

<img width="744" alt="image" src="https://user-images.githubusercontent.com/36161392/234900440-852afb12-e6a3-4672-b52e-49f112d727e9.png">
<img width="720" alt="image" src="https://user-images.githubusercontent.com/36161392/235237836-f4c7542c-ff82-49e1-990f-ca4f54e3e100.png">


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
