### PR TITLE
Uzbekistan frequency plan

### DIFF
--- a/UZ_923_1.yml
+++ b/UZ_923_1.yml
@@ -1,0 +1,36 @@
+band-id: AS_923
+sub-bands:
+- min-frequency: 926200000
+  max-frequency: 926800000
+  max-eirp: 16
+uplink-channels:
+- frequency: 926400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 926600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 926800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+
+downlink-channels:
+- frequency: 926400000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 926600000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 926800000
+  min-data-rate: 0
+  max-data-rate: 5
+
+rx2-channel:                   # Rx2 channel (optional)
+  frequency: 926200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+rx2-default-data-rate: 2    # Rx2 default data rate (optional)

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -860,3 +860,10 @@
   base-id: AS_920_923
   country-codes: [sg]
   file: SG_920_923_TTN.yml
+
+- id: UZ_923_1
+  band-id: AS_923
+  name: Uzbekistan 915-928 MHz with only default channels
+  description: Compatibility frequency plan for Uzbekistan with common channels in the 926.2-926.8 MHz sub-band
+  base-frequency: 915
+  file: UZ_923_1.yml

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -866,4 +866,5 @@
   name: Uzbekistan 915-928 MHz with only default channels
   description: Compatibility frequency plan for Uzbekistan with common channels in the 926.2-926.8 MHz sub-band
   base-frequency: 915
+  country-codes: [uz]
   file: UZ_923_1.yml


### PR DESCRIPTION
Frequency plan for Water meter projects in uzbekistan

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
This Uzbekistan frequency plan was asked for water meter projects, specifications were sent:

![image](https://github.com/TheThingsNetwork/lorawan-frequency-plans/assets/81958808/78903295-5d11-4a70-b6e2-3e082d42d3da)


#### Changes
<!-- What are the changes made in this pull request? -->

- 4 channels 926.2, 926.4, 926.6, 926.8
- 3 uplink channels 926.4, 926.6, 926.8
- RX2 in channel 926.2

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
