### PR TITLE
Single channel frequency plan for Europe

### DIFF
--- a/EU_868_1.yml
+++ b/EU_868_1.yml
@@ -1,0 +1,9 @@
+uplink-channels:
+- frequency: 868100000
+  min-data-rate: 0 
+  max-data-rate: 5
+  radio: 1
+downlink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -207,6 +207,76 @@
     ]
   file: EU_863_870_ROAMING_DRAFT.yml
 
+- id: EU_868_1
+  band-id: EU_863_870
+  name: Europe 868.1 MHz
+  description: Single channel frequency plan for Europe
+  base-frequency: 868
+  base-id: EU_863_870
+  country-codes:
+    [
+      al,
+      ad,
+      ao,
+      at,
+      bh,
+      be,
+      ba,
+      bw,
+      bg,
+      cg,
+      hr,
+      cy,
+      cz,
+      dk,
+      ee,
+      sz,
+      fi,
+      fr,
+      gr,
+      hu,
+      is,
+      ie,
+      it,
+      lv,
+      ls,
+      li,
+      lt,
+      lu,
+      mg,
+      mw,
+      mt,
+      mu,
+      md,
+      me,
+      mz,
+      na,
+      nl,
+      mk,
+      ph,
+      pl,
+      pt,
+      ro,
+      ru,
+      sa,
+      rs,
+      sc,
+      sk,
+      si,
+      za,
+      es,
+      se,
+      ch,
+      tz,
+      tr,
+      ae,
+      gb,
+      va,
+      zm,
+      zw,
+    ]
+  file: EU_868_1.yml
+
 - id: EU_433
   band-id: EU_433
   name: Europe 433 MHz (ITU region 1)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds a single channel frequency plan for Europe at 868.1 MHz.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `EU_868_1` that has 868.1 MHz for uplink and downlink.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
