### PR TITLE
Add single channel plan for United States

### DIFF
--- a/US_903_0.yml
+++ b/US_903_0.yml
@@ -1,0 +1,10 @@
+uplink-channels:
+  - frequency: 903000000
+    min-data-rate: 0
+    max-data-rate: 3
+    radio: 1
+downlink-channels:
+  - frequency: 903000000
+    min-data-rate: 0
+    max-data-rate: 3
+max-eirp: 24.15

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -361,6 +361,15 @@
   country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
   file: US_902_928_FSB_8.yml
 
+- id: US_903_0
+  band-id: US_902_928
+  name: United States 903.0 MHz
+  description: Single channel frequency plan for United States (experimental)
+  base-frequency: 915
+  base-id: US_902_928_FSB_1
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_903_0.yml
+
 - id: AU_915_928_FSB_1
   band-id: AU_915_928
   name: Australia 915-928 MHz, FSB 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds an experimental single channel frequency plan for US915.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add US_903_0 for 903.0 MHz.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
