### PR TITLE
(proposal): New shifted frequency plans for EU zone

### DIFF
--- a/EU_868_SC_8635.yml
+++ b/EU_868_SC_8635.yml
@@ -1,0 +1,80 @@
+band-id: EU_863_870
+uplink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 868300000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 868500000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 863100000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 863300000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 863500000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 863700000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 863900000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+downlink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868300000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868500000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 863100000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 863300000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 863500000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 863700000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 863900000
+  min-data-rate: 0
+  max-data-rate: 5
+lora-standard-channel:
+  frequency: 868300000 # second channel
+  data-rate: 6
+  radio: 0
+fsk-channel:
+  frequency: 867800000
+  data-rate: 7
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 868300000
+  rssi-offset: -166
+  tx:
+    min-frequency: 863000000
+    max-frequency: 870000000
+- enable: true
+  chip-type: SX1257
+  frequency: 863500000
+  rssi-offset: -166
+clock-source: 1

--- a/EU_868_SC_8650.yml
+++ b/EU_868_SC_8650.yml
@@ -1,0 +1,80 @@
+band-id: EU_863_870
+uplink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 868300000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 868500000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 864600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 864800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 865000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 865200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 865400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+downlink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868300000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868500000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 864600000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 864800000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 865000000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 865200000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 865400000
+  min-data-rate: 0
+  max-data-rate: 5
+lora-standard-channel:
+  frequency: 868300000 # second channel
+  data-rate: 6
+  radio: 0
+fsk-channel:
+  frequency: 867800000
+  data-rate: 7
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 868300000
+  rssi-offset: -166
+  tx:
+    min-frequency: 863000000
+    max-frequency: 870000000
+- enable: true
+  chip-type: SX1257
+  frequency: 865000000
+  rssi-offset: -166
+clock-source: 1

--- a/EU_868_SC_8665.yml
+++ b/EU_868_SC_8665.yml
@@ -1,0 +1,80 @@
+band-id: EU_863_870
+uplink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 868300000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 868500000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 866100000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 866300000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 866500000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 866700000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 866900000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+downlink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868300000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868500000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 866100000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 866300000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 866500000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 866700000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 866900000
+  min-data-rate: 0
+  max-data-rate: 5
+lora-standard-channel:
+  frequency: 868300000 # second channel
+  data-rate: 6
+  radio: 0
+fsk-channel:
+  frequency: 867800000
+  data-rate: 7
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 868300000
+  rssi-offset: -166
+  tx:
+    min-frequency: 863000000
+    max-frequency: 870000000
+- enable: true
+  chip-type: SX1257
+  frequency: 866500000
+  rssi-offset: -166
+clock-source: 1

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -281,6 +281,33 @@
     ]
   file: EU_868_1.yml
 
+- id: EU_863_870_1  
+  band-id: EU_863_870      
+  base-id: EU_863_870      
+  name: Region 863-870 MHz (5ch around 863.5 MHz, 3ch around 868.3 MHz) 
+  description: Frequency plan for European Union, with 5 channels within the 863.5 MHz subcarrier and 3 channels within 868.3 MHz subcarrier (LBT).
+  base-frequency: 868      
+  country-codes: [al,ad,ao,at,bh,be,ba,bw,bg,cg,hr,cy,cz,dk,ee,sz,fi,fr,gr,hu,is,ie,it,lv,ls,li,lt,lu,mg,mw,mt,mu,md,me,mz,na,nl,mk,ph,pl,pt,ro,ru,sa,rs,sc,sk,si,za,es,se,ch,tz,tr,ae,gb,va,zm,zw]
+  file: EU_868_SC_8635.yml
+
+- id: EU_863_870_2
+  band-id: EU_863_870     
+  base-id: EU_863_870     
+  name: Region 863-870 MHz (5ch around 865.0 MHz, 3ch around 868.3 MHz) 
+  description: Frequency plan for European Union, with 5 channels within the 865.0 MHz subcarrier and 3 channels within 868.3 MHz subcarrier (LBT).
+  base-frequency: 868      
+  country-codes: [al,ad,ao,at,bh,be,ba,bw,bg,cg,hr,cy,cz,dk,ee,sz,fi,fr,gr,hu,is,ie,it,lv,ls,li,lt,lu,mg,mw,mt,mu,md,me,mz,na,nl,mk,ph,pl,pt,ro,ru,sa,rs,sc,sk,si,za,es,se,ch,tz,tr,ae,gb,va,zm,zw]     
+  file: EU_868_SC_8650.yml
+
+- id: EU_863_870_3    
+  band-id: EU_863_870      
+  base-id: EU_863_870      
+  name: Region 863-870 MHz (5ch around 866.5 MHz, 3ch around 868.3 MHz) 
+  description: Frequency plan for European Union, with 5 channels within the 866.5 MHz subcarrier and 3 channels within 868.3 MHz subcarrier (LBT).
+  base-frequency: 868      
+  country-codes: [al,ad,ao,at,bh,be,ba,bw,bg,cg,hr,cy,cz,dk,ee,sz,fi,fr,gr,hu,is,ie,it,lv,ls,li,lt,lu,mg,mw,mt,mu,md,me,mz,na,nl,mk,ph,pl,pt,ro,ru,sa,rs,sc,sk,si,za,es,se,ch,tz,tr,ae,gb,va,zm,zw]
+  file: EU_868_SC_8665.yml
+
 - id: EU_433
   band-id: EU_433
   name: Europe 433 MHz (ITU region 1)


### PR DESCRIPTION
The aim of this change is to broaden the alternatives when it comes to planning a LoRaWAN network. There are such zones that have tons of devices, causing problems related with the duty cycle regulations...

BREAKING CHANGE: 3 new frequency plans proposed for EU zone

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
There are not issues to reference. This pull request has been developed after months fixing problems and maintaining a LoRaWAN that is using TheThingsNetwork solution.

The main issue was that in the zone where the devices where located the statistics of TTN stated high duty cycles among the band where the default EU channels are located.

Considering that the EU863-870 band is wider enough, this PR introduces 3 alternative frequency plans, so then TTN users do not have to deploy TheThingsStack on premises to use custom frequency plans.

#### Changes
Three new frequency plans that have 5ch situated in a different position throughout the frequency spectrum:
- EU_863_870_1 (5ch around 863.5 MHz, 3ch around 868.3 MHz) 
- EU_863_870_2 (5ch around 865.0 MHz, 3ch around 868.3 MHz)
- EU_863_870_3 (5ch around 866.5 MHz, 3ch around 868.3 MHz)

Each frequency plan tries to be conservative in the way that not all 8 channels are changed from the default EU plan. Instead, only 5 out of 8 channels are shifted.

![image](https://github.com/user-attachments/assets/8cb8e525-5e0a-4bc0-9580-5157c0b3f08e)
![image](https://github.com/user-attachments/assets/548cb642-011e-41d4-bc97-28821a5bbd79)
![image](https://github.com/user-attachments/assets/2b446d0b-d5a2-45da-ac79-0782459a0e7f)

#### Notes for Reviewers
The necessity of this breaking change in the EU frequency plans has been requested by the companies that are running LoRaWAN for their IoT products. Indeed, although you can use your custom frequency plans in TheThingsStack, is not worth for a small IoT company (start-up) to have to loose time self hosting a service to have the ability to customize it.

#### Checklist

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [X] Testing: The changes are tested.
- [X] Documentation: Relevant documentation is added or updated.
