### PR TITLE
Add remaining 500 kHz single channel plans for United States

### DIFF
--- a/US_904_6.yml
+++ b/US_904_6.yml
@@ -1,0 +1,10 @@
+uplink-channels:
+  - frequency: 904600000
+    min-data-rate: 0
+    max-data-rate: 3
+    radio: 1
+downlink-channels:
+  - frequency: 904600000
+    min-data-rate: 0
+    max-data-rate: 3
+max-eirp: 24.15

--- a/US_906_2.yml
+++ b/US_906_2.yml
@@ -1,0 +1,10 @@
+uplink-channels:
+  - frequency: 906200000
+    min-data-rate: 0
+    max-data-rate: 3
+    radio: 1
+downlink-channels:
+  - frequency: 906200000
+    min-data-rate: 0
+    max-data-rate: 3
+max-eirp: 24.15

--- a/US_907_8.yml
+++ b/US_907_8.yml
@@ -1,0 +1,10 @@
+uplink-channels:
+  - frequency: 907800000
+    min-data-rate: 0
+    max-data-rate: 3
+    radio: 1
+downlink-channels:
+  - frequency: 907800000
+    min-data-rate: 0
+    max-data-rate: 3
+max-eirp: 24.15

--- a/US_909_4.yml
+++ b/US_909_4.yml
@@ -1,0 +1,10 @@
+uplink-channels:
+  - frequency: 909400000
+    min-data-rate: 0
+    max-data-rate: 3
+    radio: 1
+downlink-channels:
+  - frequency: 909400000
+    min-data-rate: 0
+    max-data-rate: 3
+max-eirp: 24.15

--- a/US_911_0.yml
+++ b/US_911_0.yml
@@ -1,0 +1,10 @@
+uplink-channels:
+  - frequency: 911000000
+    min-data-rate: 0
+    max-data-rate: 3
+    radio: 1
+downlink-channels:
+  - frequency: 911000000
+    min-data-rate: 0
+    max-data-rate: 3
+max-eirp: 24.15

--- a/US_912_6.yml
+++ b/US_912_6.yml
@@ -1,0 +1,10 @@
+uplink-channels:
+  - frequency: 912600000
+    min-data-rate: 0
+    max-data-rate: 3
+    radio: 1
+downlink-channels:
+  - frequency: 912600000
+    min-data-rate: 0
+    max-data-rate: 3
+max-eirp: 24.15

--- a/US_914_2.yml
+++ b/US_914_2.yml
@@ -1,0 +1,10 @@
+uplink-channels:
+  - frequency: 914200000
+    min-data-rate: 0
+    max-data-rate: 3
+    radio: 1
+downlink-channels:
+  - frequency: 914200000
+    min-data-rate: 0
+    max-data-rate: 3
+max-eirp: 24.15

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -370,6 +370,69 @@
   country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
   file: US_903_0.yml
 
+- id: US_904_6
+  band-id: US_902_928
+  name: United States 904.6 MHz
+  description: Single channel frequency plan for United States (experimental)
+  base-frequency: 915
+  base-id: US_902_928_FSB_2
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_904_6.yml
+
+- id: US_906_2
+  band-id: US_902_928
+  name: United States 906.2 MHz
+  description: Single channel frequency plan for United States (experimental)
+  base-frequency: 915
+  base-id: US_902_928_FSB_3
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_906_2.yml
+
+- id: US_907_8
+  band-id: US_902_928
+  name: United States 907.8 MHz
+  description: Single channel frequency plan for United States (experimental)
+  base-frequency: 915
+  base-id: US_902_928_FSB_4
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_907_8.yml
+
+- id: US_909_4
+  band-id: US_902_928
+  name: United States 909.4 MHz
+  description: Single channel frequency plan for United States (experimental)
+  base-frequency: 915
+  base-id: US_902_928_FSB_5
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_909_4.yml
+
+- id: US_911_0
+  band-id: US_902_928
+  name: United States 911.0 MHz
+  description: Single channel frequency plan for United States (experimental)
+  base-frequency: 915
+  base-id: US_902_928_FSB_6
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_911_0.yml
+
+- id: US_912_6
+  band-id: US_902_928
+  name: United States 912.6 MHz
+  description: Single channel frequency plan for United States (experimental)
+  base-frequency: 915
+  base-id: US_902_928_FSB_7
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_912_6.yml
+
+- id: US_914_2
+  band-id: US_902_928
+  name: United States 914.2 MHz
+  description: Single channel frequency plan for United States (experimental)
+  base-frequency: 915
+  base-id: US_902_928_FSB_8
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_914_2.yml
+
 - id: AU_915_928_FSB_1
   band-id: AU_915_928
   name: Australia 915-928 MHz, FSB 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds the remaining single channel plans for United States using the 500 kHz channels.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add US_904_2 to US_912_6.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
