### PR TITLE
Fix US_902_928_CUSTOM_ADC_500KHZ band id

### DIFF
--- a/US_902_928_CUSTOM_ADC_500KHZ.yml
+++ b/US_902_928_CUSTOM_ADC_500KHZ.yml
@@ -1,4 +1,4 @@
-band-id: US_902_928_CUSTOM_ADC_500KHZ
+band-id: US_902_928_CUSTOM_ADC
 uplink-channels:
 - frequency: 903000000
   min-data-rate: 0

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -1139,7 +1139,7 @@
   file: UZ_923_1.yml
 
 - id: US_902_928_CUSTOM_ADC_500KHZ
-  band-id: US_902_928_CUSTOM_ADC_500KHZ
+  band-id: US_902_928_CUSTOM_ADC
   name: United States 902-928 MHz, Custom ADC 500kHz
   description: Custom frequency plan for ADC with 500kHz channels
   base-frequency: 915


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1405

#### Changes
<!-- What are the changes made in this pull request? -->

- Fixes the band id of the US_902_928_CUSTOM_ADC_500KHZ frequency plan

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
