### PR TITLE
Add US_902_928_CUSTOM_VIASAT frequency plans

### DIFF
--- a/US_902_928_CUSTOM_VIASAT_FSB_1.yml
+++ b/US_902_928_CUSTOM_VIASAT_FSB_1.yml
@@ -1,0 +1,55 @@
+band-id: US_902_928_CUSTOM_VIASAT
+uplink-channels:
+- frequency: 902300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 902500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 902700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 902900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 903100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 903300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 903500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 903700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+lora-standard-channel:
+  frequency: 903000000
+  data-rate: 4
+  radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 902700000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 903400000
+  rssi-offset: -166
+clock-source: 1

--- a/US_902_928_CUSTOM_VIASAT_FSB_2.yml
+++ b/US_902_928_CUSTOM_VIASAT_FSB_2.yml
@@ -1,0 +1,55 @@
+band-id: US_902_928_CUSTOM_VIASAT
+uplink-channels:
+- frequency: 903900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 904100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 904300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 904500000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 0
+- frequency: 904700000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 904900000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 905100000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+- frequency: 905300000
+  min-data-rate: 0
+  max-data-rate: 3
+  radio: 1
+lora-standard-channel:
+  frequency: 904600000
+  data-rate: 4
+  radio: 0
+dwell-time:
+  uplinks: true
+  downlinks: false
+  duration: 400ms
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 904300000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 905000000
+  rssi-offset: -166
+clock-source: 1

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -911,3 +911,21 @@
   gateways: true
   country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
   file: US_902_928_CUSTOM_ADC_500KHZ_904_6.yml
+
+- id: US_902_928_CUSTOM_VIASAT_FSB_1
+  band-id: US_902_928_CUSTOM_VIASAT
+  name: United States 902-928 MHz, Custom Viasat FSB 1
+  description: Custom frequency plan for the United States and Canada, using sub-band 1
+  base-frequency: 915
+  gateways: true
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_902_928_CUSTOM_VIASAT_FSB_1.yml
+
+- id: US_902_928_CUSTOM_VIASAT_FSB_2
+  band-id: US_902_928_CUSTOM_VIASAT
+  name: United States 902-928 MHz, Custom Viasat FSB 2
+  description: Custom frequency plan for the United States and Canada, using sub-band 2
+  base-frequency: 915
+  gateways: true
+  country-codes: [ca, cr, ec, gy, mx, pa, pr, us]
+  file: US_902_928_CUSTOM_VIASAT_FSB_2.yml


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References: https://github.com/TheThingsIndustries/lorawan-stack/issues/4887

#### Changes
<!-- What are the changes made in this pull request? -->

- Adds custom Viasat frequency plans, based on US_902_928_FSB_1 and US_902_928_FSB_2

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
